### PR TITLE
Add configuration to skip SRI for some files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Firesphere\CSPHeaders\View\CSPBackend:
       self: true
     default-src: []
     frame-src:
-      allow: 
+      allow:
         - youtube.com
       self: false
     connect-src:
@@ -61,7 +61,7 @@ Firesphere\CSPHeaders\View\CSPBackend:
       blob: true
       self: true
       data: true
-    media-src: 
+    media-src:
       allow:
         - youtube.com
         - vimeo.com
@@ -119,6 +119,16 @@ If you want to submit forms to a different domain, you can add the allowed domai
 ## inline scripts or custom scripts
 
 If you use the default methods provided by the `Requirements` class, the needed SHA's and SRI's are automatically calculated for you.
+
+## Skipping SRI for some files
+
+You can specify files or domains to skip outputting (JS or CSS) SRI for using the `files_to_skip_sri` array. If the file URI starts with or matches a value in this array then it will be skipped. In the example below, any files fetched from https://maps.googleapis.com/ would be skipped.
+
+```yaml
+Firesphere\CSPHeaders\Builders\SRIBuilder:
+  files_to_skip_sri:
+    - 'https://maps.googleapis.com/'
+```
 
 # Refreshing calculated values
 

--- a/readme.md
+++ b/readme.md
@@ -122,11 +122,11 @@ If you use the default methods provided by the `Requirements` class, the needed 
 
 ## Skipping SRI for some files
 
-You can specify files or domains to skip outputting (JS or CSS) SRI for using the `files_to_skip_sri` array. If the file URI starts with or matches a value in this array then it will be skipped. In the example below, any files fetched from https://maps.googleapis.com/ would be skipped.
+You can specify files or domains to skip outputting (JS or CSS) SRI for by using the `skip_domains` array. If the file URI starts with or matches a value in this array then it will be skipped. In the example below, any files fetched from https://maps.googleapis.com/ would be skipped.
 
 ```yaml
 Firesphere\CSPHeaders\Builders\SRIBuilder:
-  files_to_skip_sri:
+  skip_domains:
     - 'https://maps.googleapis.com/'
 ```
 

--- a/src/Builders/SRIBuilder.php
+++ b/src/Builders/SRIBuilder.php
@@ -23,7 +23,7 @@ class SRIBuilder
      * 'https://example.com' then all scripts from that site will be skipped.
      * @var array
      */
-    private static $files_to_skip_sri = [];
+    private static $skip_domains = [];
 
     /**
      * @param $file
@@ -34,7 +34,7 @@ class SRIBuilder
      */
     public function buildSRI($file, array $htmlAttributes): array
     {
-        $skipFiles = $this->config()->get('files_to_skip_sri');
+        $skipFiles = $this->config()->get('skip_domains');
         foreach ($skipFiles as $filename) {
             if (strpos($file, $filename) === 0) {
                 return $htmlAttributes;

--- a/tests/unit/SRIBuilderTest.php
+++ b/tests/unit/SRIBuilderTest.php
@@ -32,4 +32,15 @@ class SRIBuilderTest extends SapphireTest
         $expected = sprintf('%s-%s', CSPBackend::SHA384, base64_encode(hash(CSPBackend::SHA384, $contents, true)));
         $this->assertEquals(['integrity' => $expected, 'crossorigin' => ''], $builder->buildSRI('composer.json', []));
     }
+
+    public function testSkipDomains()
+    {
+        $builder = new SRIBuilder();
+        $builder->buildSRI('composer.json', []);
+        // skip files starting with composer
+        $builder->config()->set('skip_domains', ['composer']);
+        Cookie::set('buildHeaders', 'true');
+        // Should not have added integrity to the array
+        $this->assertEquals([], $builder->buildSRI('composer.json', []));
+    }
 }


### PR DESCRIPTION
Some external resources do not allow you to use SRI, including Google maps. See more about the reasoning here
https://stackoverflow.com/questions/39374880/sub-resource-integrity-value-for-maps-google-com-maps-api-js