### PR TITLE
Allow CSP and SRI in UAT/test environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .idea
 .php_cs.cache
+/vendor
+/app
+/composer.lock
+/resources
+/_resources

--- a/_config/csp.yml
+++ b/_config/csp.yml
@@ -3,6 +3,7 @@ Name: CSPHeaders
 ---
 Firesphere\CSPHeaders\View\CSPBackend:
   csp_config:
+    enabled: true
     report-only: false
     report-uri: "https://127.0.0.1/r/d/csp/enforce"
     base-uri:

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ Default for css is therefore `false`, javascript however defaults to `true` for 
 
 Firesphere\CSPHeaders\View\CSPBackend:
   csp_config:
+    enabled: true
     report-only: false
     report-uri: "https://mydomain.report-uri.com"
     base-uri:
@@ -99,7 +100,19 @@ When you enable the Reporting API you will receive deprecation, intervention and
 
 ## csp_config
 
-Configure the allowed domains. If domains change, they need to be added programmatically.
+Configure the allowed domains. If domains change, they need to be added programmatically. You can disable CSP output entirely for target environments via yaml e.g. to only output the headers in production you could use
+
+```yaml
+---
+Except:
+  environment: 'live'
+---
+Firesphere\CSPHeaders\View\CSPBackend:
+  csp_config:
+    enabled: false
+```
+
+You can also use this to skip generating SRI for JS or CSS within target environments.
 
 ### Using a nonce
 

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ Configure the allowed domains. If domains change, they need to be added programm
 
 ### Using a nonce
 
-If you don't want to use the script tag, use the nonce. In the template, you can use `$Nonce` to get the current request nonce, e.g. if you are using <script> tags in your template
+In the template, you can use `$Nonce` to get the current request nonce, e.g. if you are using <script> tags in your template instead of using the Requirements API. Note that using <script> tags will not generate or output SRI.
 
 ## wizard
 
@@ -134,7 +134,7 @@ Firesphere\CSPHeaders\Builders\SRIBuilder:
 
 To force-refresh the SRI calculations, add the URL Parameter `?updatesri=true`. You need to be admin to use this.
 
-To force the headers to be set in dev-mode, for testing purposes, add the URL parameter `?build-headers=true`.
+To force the headers to be set, for testing purposes, add the URL parameter `?build-headers=true`.
 To disable this again, change the `true` to `false`
 
 To have these automatically clear out on a dev/build (useful for updating integrity hashes on production when new assets are deployed) you can enable this via the yaml below - though note this only works on Silverstripe framework 4.7+

--- a/src/Builders/CSSBuilder.php
+++ b/src/Builders/CSSBuilder.php
@@ -3,6 +3,7 @@
 
 namespace Firesphere\CSPHeaders\Builders;
 
+use Firesphere\CSPHeaders\Extensions\ControllerCSPExtension;
 use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Core\Injector\Injector;
@@ -46,7 +47,10 @@ class CSSBuilder extends BaseBuilder implements BuilderInterface
             'href' => $path,
         ], $attributes);
 
-        if (CSPBackend::isCssSRI()) {
+
+        $request = Controller::has_curr() ? Controller::curr()->getRequest() : null;
+        $cookieSet = $request ? ControllerCSPExtension::checkCookie($request) : false;
+        if (CSPBackend::isCssSRI() || $cookieSet) {
             $htmlAttributes = $this->getSriBuilder()->buildSRI($file, $htmlAttributes);
         }
 

--- a/src/Builders/CSSBuilder.php
+++ b/src/Builders/CSSBuilder.php
@@ -8,6 +8,7 @@ use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\HTML;
 

--- a/src/Builders/CSSBuilder.php
+++ b/src/Builders/CSSBuilder.php
@@ -6,6 +6,7 @@ namespace Firesphere\CSPHeaders\Builders;
 use Firesphere\CSPHeaders\Extensions\ControllerCSPExtension;
 use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
+use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\HTML;

--- a/src/Builders/CSSBuilder.php
+++ b/src/Builders/CSSBuilder.php
@@ -8,7 +8,6 @@ use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\HTML;
 

--- a/src/Builders/JSBuilder.php
+++ b/src/Builders/JSBuilder.php
@@ -8,6 +8,7 @@ use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\HTML;
 

--- a/src/Builders/JSBuilder.php
+++ b/src/Builders/JSBuilder.php
@@ -6,6 +6,7 @@ namespace Firesphere\CSPHeaders\Builders;
 use Firesphere\CSPHeaders\Extensions\ControllerCSPExtension;
 use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
+use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\HTML;

--- a/src/Builders/JSBuilder.php
+++ b/src/Builders/JSBuilder.php
@@ -3,6 +3,7 @@
 
 namespace Firesphere\CSPHeaders\Builders;
 
+use Firesphere\CSPHeaders\Extensions\ControllerCSPExtension;
 use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Core\Injector\Injector;
@@ -47,7 +48,9 @@ class JSBuilder extends BaseBuilder implements BuilderInterface
         ], $attributes);
 
         // Build SRI if it's enabled
-        if (CSPBackend::isJsSRI()) {
+        $request = Controller::has_curr() ? Controller::curr()->getRequest() : null;
+        $cookieSet = $request ? ControllerCSPExtension::checkCookie($request) : false;
+        if (CSPBackend::isJsSRI() || $cookieSet) {
             $htmlAttributes = $this->getSriBuilder()->buildSRI($file, $htmlAttributes);
         }
         // Use nonces for inlines if requested

--- a/src/Builders/JSBuilder.php
+++ b/src/Builders/JSBuilder.php
@@ -8,7 +8,6 @@ use Firesphere\CSPHeaders\Interfaces\BuilderInterface;
 use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\HTML;
 

--- a/src/Builders/SRIBuilder.php
+++ b/src/Builders/SRIBuilder.php
@@ -4,14 +4,14 @@
 namespace Firesphere\CSPHeaders\Builders;
 
 use Exception;
-use Firesphere\CSPHeaders\Extensions\ControllerCSPExtension;
 use Firesphere\CSPHeaders\Models\SRI;
 use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\ORM\ValidationException;
-use SilverStripe\Security\Security;
+use SilverStripe\View\ArrayData;
+use SilverStripe\Security\Permission;
 
 class SRIBuilder
 {
@@ -74,7 +74,7 @@ class SRIBuilder
         // Is updateSRI requested?
         return (Controller::curr()->getRequest()->getVar('updatesri') &&
             // Does the user have the powers
-            ((Security::getCurrentUser() && Security::getCurrentUser()->inGroup('administrators')) ||
+            (Permission::check('ADMIN', 'any') ||
                 // OR the site is in dev mode
                 Director::isDev()));
     }

--- a/src/Builders/SRIBuilder.php
+++ b/src/Builders/SRIBuilder.php
@@ -26,6 +26,12 @@ class SRIBuilder
     private static $skip_domains = [];
 
     /**
+     * List of the SRI's
+     * @var ArrayList|SRI[]
+     */
+    private static $sri;
+
+    /**
      * @param $file
      * @param array $htmlAttributes
      * @return array

--- a/src/Builders/SRIBuilder.php
+++ b/src/Builders/SRIBuilder.php
@@ -9,6 +9,7 @@ use Firesphere\CSPHeaders\View\CSPBackend;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\ArrayData;
 use SilverStripe\Security\Permission;

--- a/src/Extensions/ControllerCSPExtension.php
+++ b/src/Extensions/ControllerCSPExtension.php
@@ -116,6 +116,7 @@ class ControllerCSPExtension extends Extension
             $this->addInlineCSSPolicy($policy, $config);
             // When in dev, add the debugbar nonce, requires a change to the lib
             if (Director::isDev() && class_exists('LeKoala\DebugBar\DebugBar')) {
+                \LeKoala\DebugBar\DebugBar::getDebugBar()->getJavascriptRenderer()->setCspNonce('debugbar');
                 $policy->nonce('script-src', 'debugbar');
             }
 

--- a/src/Extensions/ControllerCSPExtension.php
+++ b/src/Extensions/ControllerCSPExtension.php
@@ -96,18 +96,16 @@ class ControllerCSPExtension extends Extension
      */
     public function onBeforeInit()
     {
-        if (!DatabaseAdmin::lastBuilt() || !Controller::has_curr() || get_class(Controller::curr()) === DatabaseAdmin::class) {
-            // Skip if we've not built the database yet or on dev/build requests
-            return;
-        }
         /** @var ContentController $owner */
         $owner = $this->owner;
-        $this->addPolicyHeaders = Director::isLive() || static::checkCookie($owner->getRequest());
+        $ymlConfig = CSPBackend::config()->get('csp_config');
+        $this->addPolicyHeaders = ($ymlConfig['enabled'] ?? false) || static::checkCookie($owner->getRequest());
+        /** @var Controller $owner */
+        $owner = $this->owner;
         if ($this->addPolicyHeaders) {
             if (!$this->getNonce() && CSPBackend::isUsesNonce()) {
                 $this->nonce = Base64::encode(hash('sha512', uniqid('nonce', true) . time()));
             }
-            $ymlConfig = CSPBackend::config()->get('csp_config');
             $config = Injector::inst()->convertServiceProperty($ymlConfig);
             $legacy = $config['legacy'] ?? true;
 
@@ -117,8 +115,7 @@ class ControllerCSPExtension extends Extension
             $this->addInlineJSPolicy($policy, $config);
             $this->addInlineCSSPolicy($policy, $config);
             // When in dev, add the debugbar nonce, requires a change to the lib
-            if (Director::isDev() && class_exists('LeKoala\DebugBar\DebugBar')) {
-                \LeKoala\DebugBar\DebugBar::getDebugBar()->getJavascriptRenderer()->setCspNonce('debugbar');
+            if (Director::isDev() && class_exists(DebugBar::class)) {
                 $policy->nonce('script-src', 'debugbar');
             }
 

--- a/src/Extensions/ControllerCSPExtension.php
+++ b/src/Extensions/ControllerCSPExtension.php
@@ -115,7 +115,7 @@ class ControllerCSPExtension extends Extension
             $this->addInlineJSPolicy($policy, $config);
             $this->addInlineCSSPolicy($policy, $config);
             // When in dev, add the debugbar nonce, requires a change to the lib
-            if (Director::isDev() && class_exists(DebugBar::class)) {
+            if (Director::isDev() && class_exists('LeKoala\DebugBar\DebugBar')) {
                 $policy->nonce('script-src', 'debugbar');
             }
 

--- a/tests/unit/CSSBuilderTest.php
+++ b/tests/unit/CSSBuilderTest.php
@@ -117,7 +117,7 @@ class CSSBuilderTest extends SapphireTest
         // Should add integrity
         CSPBackend::config()->update('cssSRI', true);
         $this->assertTrue(CSPBackend::isCssSRI());
-        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $requirements = $builder->buildTags('composer.json', [], [], '/');
         $this->assertContains('integrity=', $requirements);
         // Shouldn't add integrity if not enabled
         CSPBackend::config()->update('cssSRI', false);

--- a/tests/unit/CSSBuilderTest.php
+++ b/tests/unit/CSSBuilderTest.php
@@ -118,21 +118,21 @@ class CSSBuilderTest extends SapphireTest
         CSPBackend::config()->update('cssSRI', true);
         $this->assertTrue(CSPBackend::isCssSRI());
         $requirements = $builder->buildTags('composer.json', [], [], '/');
-        $this->assertContains('integrity=', $requirements);
+        $this->assertContains('integrity=', $requirements[0]);
         // Shouldn't add integrity if not enabled
         CSPBackend::config()->update('cssSRI', false);
         $this->assertFalse(CSPBackend::isCssSRI());
         $controller->onBeforeInit();
-        $requirements = $builder->buildTags('composer.json', [], '', '/');
-        $this->assertNotContains('integrity=', $requirements);
+        $requirements = $builder->buildTags('composer.json', [], [], '/');
+        $this->assertNotContains('integrity=', $requirements[0]);
 
         // Should add integrity if not enabled but forced by build headers in request
         $request = Controller::curr()->getRequest();
         $request->offsetSet('build-headers', 'true');
         $controller->onBeforeInit();
         $this->assertFalse(CSPBackend::isCssSRI());
-        $requirements = $builder->buildTags('composer.json', [], '', '/');
-        $this->assertContains('integrity=', $requirements);
+        $requirements = $builder->buildTags('composer.json', [], [], '/');
+        $this->assertContains('integrity=', $requirements[0]);
         $request->offsetUnset('build-headers');
         Cookie::force_expiry('buildHeaders');
     }

--- a/tests/unit/CSSBuilderTest.php
+++ b/tests/unit/CSSBuilderTest.php
@@ -5,15 +5,16 @@ namespace Firesphere\CSPHeaders\Tests;
 
 use Firesphere\CSPHeaders\Builders\CSSBuilder;
 use Firesphere\CSPHeaders\Builders\SRIBuilder;
-use Firesphere\CSPHeaders\View\CSPBackend;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Control\Controller;
-use SilverStripe\Control\Session;
-use SilverStripe\Control\HTTPRequest;
 use Firesphere\CSPHeaders\Extensions\ControllerCSPExtension;
-use SilverStripe\Core\Injector\Injector;
+use Firesphere\CSPHeaders\View\CSPBackend;
 use Page;
 use PageController;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Cookie;
+use SilverStripe\Control\Session;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\View\Requirements;
 
 class CSSBuilderTest extends SapphireTest
@@ -23,13 +24,13 @@ class CSSBuilderTest extends SapphireTest
      */
     private function BuildController()
     {
-        CSPBackend::config()->set('jsSRI', false);
+        CSPBackend::config()->set('cssSRI', true);
         CSPBackend::setUsesNonce(false);
         $backend = Injector::inst()->get(CSPBackend::class);
         Requirements::set_backend($backend);
 
         $page = new Page();
-        $request = new HTTPRequest('GET', '/', ['build-headers' => 'true']);
+        $request = new HTTPRequest('GET', '/');
         $request->setSession(new Session('test'));
 
         PageController::add_extension(Controller::class, ControllerCSPExtension::class);
@@ -106,5 +107,33 @@ class CSSBuilderTest extends SapphireTest
 
         $tag = $builder->getCustomTags([]);
         $this->assertNotContains('nonce=', $tag[0]);
+    }
+
+    public function testDisableBuildTags()
+    {
+        $controller = $this->buildController();
+        $owner = Requirements::backend();
+        $builder = $owner->getCSSBuilder();
+        // Should add integrity
+        CSPBackend::config()->update('cssSRI', true);
+        $this->assertTrue(CSPBackend::isCssSRI());
+        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $this->assertContains('integrity=', $requirements);
+        // Shouldn't add integrity if not enabled
+        CSPBackend::config()->update('cssSRI', false);
+        $this->assertFalse(CSPBackend::isCssSRI());
+        $controller->onBeforeInit();
+        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $this->assertNotContains('integrity=', $requirements);
+
+        // Should add integrity if not enabled but forced by build headers in request
+        $request = Controller::curr()->getRequest();
+        $request->offsetSet('build-headers', 'true');
+        $controller->onBeforeInit();
+        $this->assertFalse(CSPBackend::isCssSRI());
+        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $this->assertContains('integrity=', $requirements);
+        $request->offsetUnset('build-headers');
+        Cookie::force_expiry('buildHeaders');
     }
 }

--- a/tests/unit/JSBuilderTest.php
+++ b/tests/unit/JSBuilderTest.php
@@ -5,16 +5,17 @@ namespace Firesphere\CSPHeaders\Tests;
 
 use Firesphere\CSPHeaders\Builders\JSBuilder;
 use Firesphere\CSPHeaders\Builders\SRIBuilder;
-use Firesphere\CSPHeaders\View\CSPBackend;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Control\Controller;
-use SilverStripe\Control\Session;
-use SilverStripe\Control\HTTPRequest;
 use Firesphere\CSPHeaders\Extensions\ControllerCSPExtension;
+use Firesphere\CSPHeaders\View\CSPBackend;
 use Page;
 use PageController;
-use SilverStripe\View\Requirements;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Cookie;
+use SilverStripe\Control\Session;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\View\Requirements;
 
 class JSBuilderTest extends SapphireTest
 {
@@ -23,13 +24,13 @@ class JSBuilderTest extends SapphireTest
      */
     private function BuildController()
     {
-        CSPBackend::config()->set('jsSRI', false);
+        CSPBackend::config()->set('jsSRI', true);
         CSPBackend::setUsesNonce(false);
         $backend = Injector::inst()->get(CSPBackend::class);
         Requirements::set_backend($backend);
 
         $page = new Page();
-        $request = new HTTPRequest('GET', '/', ['build-headers' => 'true']);
+        $request = new HTTPRequest('GET', '/');
         $request->setSession(new Session('test'));
 
         PageController::add_extension(Controller::class, ControllerCSPExtension::class);
@@ -106,5 +107,34 @@ class JSBuilderTest extends SapphireTest
 
         $tag = $builder->getCustomTags([]);
         $this->assertNotContains('nonce=', $tag[0]);
+    }
+
+    public function testDisableBuildTags()
+    {
+        $controller = $this->buildController();
+        $owner = Requirements::backend();
+        $builder = $owner->getJsBuilder();
+        // Should add integrity
+        $this->assertTrue(CSPBackend::isJsSRI());
+        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $this->assertContains('integrity=', $requirements);
+
+        // Shouldn't add integrity if not enabled
+        CSPBackend::config()->update('jsSRI', false);
+        $this->assertFalse(CSPBackend::isJsSRI());
+        $controller->onBeforeInit();
+        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $this->assertNotContains('integrity=', $requirements);
+
+        // Should add integrity if not enabled but forced by build headers in request
+        $request = Controller::curr()->getRequest();
+        $request->offsetSet('build-headers', 'true');
+        $this->assertFalse(CSPBackend::isJsSRI());
+        $controller->onBeforeInit();
+        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $this->assertContains('integrity=', $requirements);
+        CSPBackend::config()->update('jsSRI', true);
+        $request->offsetUnset('build-headers');
+        Cookie::force_expiry('buildHeaders');
     }
 }

--- a/tests/unit/JSBuilderTest.php
+++ b/tests/unit/JSBuilderTest.php
@@ -117,22 +117,22 @@ class JSBuilderTest extends SapphireTest
         // Should add integrity
         $this->assertTrue(CSPBackend::isJsSRI());
         $requirements = $builder->buildTags('composer.json', [], [], '/');
-        $this->assertContains('integrity=', $requirements);
+        $this->assertContains('integrity=', $requirements[0]);
 
         // Shouldn't add integrity if not enabled
         CSPBackend::config()->update('jsSRI', false);
         $this->assertFalse(CSPBackend::isJsSRI());
         $controller->onBeforeInit();
-        $requirements = $builder->buildTags('composer.json', [], '', '/');
-        $this->assertNotContains('integrity=', $requirements);
+        $requirements = $builder->buildTags('composer.json', [], [], '/');
+        $this->assertNotContains('integrity=', $requirements[0]);
 
         // Should add integrity if not enabled but forced by build headers in request
         $request = Controller::curr()->getRequest();
         $request->offsetSet('build-headers', 'true');
         $this->assertFalse(CSPBackend::isJsSRI());
         $controller->onBeforeInit();
-        $requirements = $builder->buildTags('composer.json', [], '', '/');
-        $this->assertContains('integrity=', $requirements);
+        $requirements = $builder->buildTags('composer.json', [], [], '/');
+        $this->assertContains('integrity=', $requirements[0]);
         CSPBackend::config()->update('jsSRI', true);
         $request->offsetUnset('build-headers');
         Cookie::force_expiry('buildHeaders');

--- a/tests/unit/JSBuilderTest.php
+++ b/tests/unit/JSBuilderTest.php
@@ -116,7 +116,7 @@ class JSBuilderTest extends SapphireTest
         $builder = $owner->getJsBuilder();
         // Should add integrity
         $this->assertTrue(CSPBackend::isJsSRI());
-        $requirements = $builder->buildTags('composer.json', [], '', '/');
+        $requirements = $builder->buildTags('composer.json', [], [], '/');
         $this->assertContains('integrity=', $requirements);
 
         // Shouldn't add integrity if not enabled

--- a/tests/unit/SRIBuilderTest.php
+++ b/tests/unit/SRIBuilderTest.php
@@ -27,8 +27,6 @@ class SRIBuilderTest extends SapphireTest
         $sriCheck = SRI::findOrCreate('composer.json');
         $this->assertEquals($sriCheck, $sri);
 
-        Cookie::set('buildHeaders', 'true');
-
         $expected = sprintf('%s-%s', CSPBackend::SHA384, base64_encode(hash(CSPBackend::SHA384, $contents, true)));
         $this->assertEquals(['integrity' => $expected, 'crossorigin' => ''], $builder->buildSRI('composer.json', []));
     }


### PR DESCRIPTION
This makes it possible to configure the module such that CSP and SRI are enabled in test environments if desired. This reduces our chance of pushing code which is otherwise tested to production to then realise it gets blocked by CSP or the SRI isn't being calculated for some reason.

Fixes #22 including the issue of depending on a group named 'administrators' which can be renamed in the CMS.