### PR TITLE
issue #35: Check for database existence the same way the framework does instead of using lastBuilt()

### DIFF
--- a/src/Extensions/ControllerCSPExtension.php
+++ b/src/Extensions/ControllerCSPExtension.php
@@ -17,8 +17,10 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\DatabaseAdmin;
 use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DB;
 use function hash;
 
 /**
@@ -96,7 +98,7 @@ class ControllerCSPExtension extends Extension
      */
     public function onBeforeInit()
     {
-        if (!DatabaseAdmin::lastBuilt() || !Controller::has_curr() || get_class(Controller::curr()) === DatabaseAdmin::class) {
+        if (!DB::is_active() || !ClassInfo::hasTable('SiteTree') || Director::is_cli()) {
             // Skip if we've not built the database yet or on dev/build requests
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/Firesphere/silverstripe-csp-headers/issues/35 and also
handles situation where cache is emptied between builds. 

Basically DatabaseAdmin::lastBuilt() is using a transient file that can be cleared 
or might not be shared between site instances in a multiple webserver setup. 

(Unclear on how to run the tests for this outside CI but I'm guessing that i'll see CI results on PR submission?)